### PR TITLE
Fix passing argument to Lighting Trainer

### DIFF
--- a/embeddings/pipeline/lightning_classification.py
+++ b/embeddings/pipeline/lightning_classification.py
@@ -53,7 +53,8 @@ class LightningClassificationPipeline(
         )
         trainer = pl.Trainer(
             default_root_dir=output_path,
-            **task_train_kwargs if task_train_kwargs else self.DEFAULT_TASK_TRAIN_KWARGS
+            **{**task_train_kwargs, **self.DEFAULT_TASK_TRAIN_KWARGS}
+            if task_train_kwargs else self.DEFAULT_TASK_TRAIN_KWARGS,
         )
 
         task = TextClassification(

--- a/embeddings/pipeline/lightning_sequence_labeling.py
+++ b/embeddings/pipeline/lightning_sequence_labeling.py
@@ -60,7 +60,8 @@ class LightningSequenceLabelingPipeline(
         )
         trainer = pl.Trainer(
             default_root_dir=output_path,
-            **task_train_kwargs if task_train_kwargs else self.DEFAULT_TASK_TRAIN_KWARGS,
+            **{**task_train_kwargs, **self.DEFAULT_TASK_TRAIN_KWARGS}
+            if task_train_kwargs else self.DEFAULT_TASK_TRAIN_KWARGS,
         )
 
         task = SequenceLabeling(


### PR DESCRIPTION
DEFAULT_TASK_TRAIN_KWARGS needs to be passed to the Trainer in order GPU to be used. 

I came across it when running LightningSequenceLabelingPipeline with addictional (optional) argument:
task_train_kwargs={"max_epochs": 10}
