### PR TITLE
fix: change type of predict subset in metadata class

### DIFF
--- a/embeddings/pipeline/lightning_hps_pipeline.py
+++ b/embeddings/pipeline/lightning_hps_pipeline.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field
 from tempfile import TemporaryDirectory
 from typing import Any, Dict, Generic, Optional, Tuple
 
+from embeddings.data.dataset import LightingDataModuleSubset
 from embeddings.evaluator.sequence_labeling_evaluator import (
     EvaluationMode,
     SequenceLabelingEvaluator,
@@ -68,7 +69,7 @@ class OptimizedLightingPipeline(
 
     def _get_evaluation_metadata(self, parameters: SampledParameters) -> LightningMetadata:
         metadata = self._get_metadata(parameters)
-        metadata["predict_subset"] = "dev"
+        metadata["predict_subset"] = LightingDataModuleSubset.VALIDATION
         metadata["dataset_name_or_path"] = self.tmp_dataset_dir.name
         metadata["output_path"] = self.tmp_model_output_dir.name
         return metadata
@@ -175,7 +176,7 @@ class OptimizedLightingClassificationPipeline(
             "task_model_kwargs": task_model_kwargs,
             "task_train_kwargs": task_train_kwargs,
             "model_config_kwargs": model_config_kwargs,
-            "predict_subset": "test",
+            "predict_subset": LightingDataModuleSubset.TEST,
         }
         return metadata
 
@@ -244,6 +245,6 @@ class OptimizedLightingSequenceLabelingPipeline(
             "task_model_kwargs": task_model_kwargs,
             "task_train_kwargs": task_train_kwargs,
             "model_config_kwargs": model_config_kwargs,
-            "predict_subset": "test",
+            "predict_subset": LightingDataModuleSubset.TEST,
         }
         return metadata

--- a/embeddings/pipeline/pipelines_metadata.py
+++ b/embeddings/pipeline/pipelines_metadata.py
@@ -2,6 +2,7 @@ from typing import Any, Dict, Optional, Tuple, TypeVar
 
 from typing_extensions import Literal, TypedDict
 
+from embeddings.data.dataset import LightingDataModuleSubset
 from embeddings.data.io import T_path
 from embeddings.evaluator.sequence_labeling_evaluator import EvaluationMode, TaggingScheme
 
@@ -73,7 +74,7 @@ class LightningPipelineMetadata(EmbeddingPipelineBaseMetadata):
     tokenizer_kwargs: Optional[Dict[str, Any]]
     batch_encoding_kwargs: Optional[Dict[str, Any]]
     model_config_kwargs: Optional[Dict[str, Any]]
-    predict_subset: Literal["dev", "test"]
+    predict_subset: Literal[LightingDataModuleSubset.VALIDATION, LightingDataModuleSubset.TEST]
 
 
 class LightningClassificationPipelineMetadata(LightningPipelineMetadata):

--- a/tests/test_hyperparameter_search.py
+++ b/tests/test_hyperparameter_search.py
@@ -5,6 +5,7 @@ import optuna
 import pytest
 from pydantic import create_model_from_typeddict
 
+from embeddings.data.dataset import LightingDataModuleSubset
 from embeddings.hyperparameter_search.parameters import SearchableParameter
 from embeddings.pipeline.flair_classification import FlairClassificationPipeline
 from embeddings.pipeline.flair_pair_classification import FlairPairClassificationPipeline
@@ -97,7 +98,7 @@ def lightning_classification_kwargs(output_path: "TemporaryDirectory[str]") -> D
         "datamodule_kwargs": None,
         "tokenizer_kwargs": None,
         "batch_encoding_kwargs": None,
-        "predict_subset": "test",
+        "predict_subset": LightingDataModuleSubset.TEST,
     }
 
 


### PR DESCRIPTION
Quick fix of incompatible types. `predict_subset` in `LightingDataModuleSubset` requires `LightingDataModuleSubset`.