### PR TITLE
feat(webpage): show expansio/qa-* display names for QA datasets in listing

### DIFF
--- a/webpage/layouts/shortcodes/datasets.html
+++ b/webpage/layouts/shortcodes/datasets.html
@@ -8,10 +8,21 @@
     "clarin-pl/aspectemo"
     "laugustyniak/political-advertising-pl"}}
 
-{{ $newDatasets := slice 
+{{ $newDatasets := slice
     "dialogue-acts"
     "laugustyniak/abusive-clauses-pl"
-    "clarin-pl/dialogue-acts"}}
+    "clarin-pl/dialogue-acts"
+    "qa_wikipedia"
+    "qa_nkjp"
+    "qa_kpwr"
+    "qa_all"}}
+
+{{ $displayNames := dict
+    "qa_wikipedia" "expansio/qa-wikipedia"
+    "qa_nkjp" "expansio/qa-nkjp"
+    "qa_kpwr" "expansio/qa-kpwr"
+    "qa_all" "expansio/qa-all"
+}}
 
 <style> 
 .accordion-item{
@@ -23,7 +34,7 @@
         <div class="accordion-item">
         <h2 class="accordion-header" id="heading{{$dataset}}">
             <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapse{{$i}}" aria-expanded="false">
-                {{ $dataset }}
+                {{ index $displayNames $dataset | default $dataset }}
                 {{ range $new := $newBDatasets}}
                     {{if (eq $dataset $new)}}
                         <sup style="color: royalblue;">&MediumSpace;New benchmark!</sup>


### PR DESCRIPTION
Renders the QA datasets in the dataset listing using their canonical HF naming (`expansio/qa-wikipedia`, `expansio/qa-nkjp`, `expansio/qa-kpwr`, `expansio/qa-all`) instead of the internal slug (`qa_wikipedia` etc.). Other datasets keep their existing display names.

Also adds the four QA datasets to the "New dataset!" badge list.

Dataset descriptions are already published in [CLARIN-PL/lepiszcze-datatasets-descriptions](https://github.com/CLARIN-PL/lepiszcze-datatasets-descriptions) and HF dataset cards are uploaded under [expansio](https://huggingface.co/expansio).